### PR TITLE
Feat/force destroy options s3 ecr

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,16 @@ provider "zenml" {
 }
 
 module "zenml_stack" {
-  source  = "zenml-io/zenml-stack/aws"
+  source           = "zenml-io/zenml-stack/aws"
 
-  orchestrator = "sagemaker" # or "skypilot" or "local"
+  orchestrator     = "sagemaker" # or "skypilot" or "local"
   zenml_stack_name = "my-zenml-stack"
+  s3_force_destroy = false
+  ecr_force_delete = false
 }
+
+# ^^^Set `s3_force_destroy` and `ecr_force_delete` to true to allow deleting non-empty S3 bucket and ECR repository during terraform destroy
+# If set to false (default), destroying the stack will fail if the S3 bucket or ECR repository is not empty
 
 output "zenml_stack_id" {
   value = module.zenml_stack.zenml_stack.id

--- a/main.tf
+++ b/main.tf
@@ -44,11 +44,13 @@ resource "random_id" "resource_name_suffix" {
 }
 
 resource "aws_s3_bucket" "artifact_store" {
-  bucket = "zenml-${data.aws_caller_identity.current.account_id}-${random_id.resource_name_suffix.hex}"
+  bucket        = "zenml-${data.aws_caller_identity.current.account_id}-${random_id.resource_name_suffix.hex}"
+  force_destroy = var.s3_force_destroy
 }
 
 resource "aws_ecr_repository" "container_registry" {
-  name = "zenml-${random_id.resource_name_suffix.hex}"
+  name         = "zenml-${random_id.resource_name_suffix.hex}"
+  force_delete = var.ecr_force_delete
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -350,8 +350,8 @@ resource "aws_iam_role_policy_attachment" "app_runner_deployer_policy" {
 # Client permissions needed for the App Runner deployer
 resource "aws_iam_role_policy" "app_runner_deployer_policy" {
   count = local.use_app_runner ? 1 : 0
-  name = "AppRunnerDeployerPolicy"
-  role = aws_iam_role.stack_access_role.id
+  name  = "AppRunnerDeployerPolicy"
+  role  = aws_iam_role.stack_access_role.id
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -359,13 +359,13 @@ resource "aws_iam_role_policy" "app_runner_deployer_policy" {
       {
         Effect = "Allow"
         Action = [
-            "secretsmanager:CreateSecret",
-            "secretsmanager:GetSecretValue",
-            "secretsmanager:DescribeSecret",
-            "secretsmanager:PutSecretValue",
-            "secretsmanager:UpdateSecret",
-            "secretsmanager:TagResource",
-            "secretsmanager:DeleteSecret"
+          "secretsmanager:CreateSecret",
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:PutSecretValue",
+          "secretsmanager:UpdateSecret",
+          "secretsmanager:TagResource",
+          "secretsmanager:DeleteSecret"
         ],
         Resource = "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:zenml-${random_id.resource_name_suffix.hex}*"
       },
@@ -378,7 +378,7 @@ resource "aws_iam_role_policy" "app_runner_deployer_policy" {
         Effect   = "Allow"
         Action   = "iam:PassRole"
         Resource = aws_iam_role.stack_access_role.arn
-      }      
+      }
     ]
   })
 }
@@ -502,7 +502,7 @@ resource "aws_iam_role_policy" "codebuild_runtime_policy" {
 
 
 resource "aws_iam_role" "app_runner_instance_role" {
-  name = "zenml-${random_id.resource_name_suffix.hex}-app-runner"
+  name  = "zenml-${random_id.resource_name_suffix.hex}-app-runner"
   count = local.use_app_runner ? 1 : 0
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -521,15 +521,15 @@ resource "aws_iam_role" "app_runner_instance_role" {
 # App Runner instance runtime permissions
 resource "aws_iam_role_policy" "app_runner_instance_policy" {
   count = local.use_app_runner ? 1 : 0
-  name = "AppRunnerInstancePolicy"
-  role = aws_iam_role.app_runner_instance_role[0].id
+  name  = "AppRunnerInstancePolicy"
+  role  = aws_iam_role.app_runner_instance_role[0].id
 
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
-        Effect = "Allow"
-        Action = "secretsmanager:GetSecretValue"
+        Effect   = "Allow"
+        Action   = "secretsmanager:GetSecretValue"
         Resource = "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:zenml-${random_id.resource_name_suffix.hex}*"
       }
     ]
@@ -807,15 +807,15 @@ resource "zenml_stack_component" "image_builder" {
 
 locals {
   deployer_config = {
-    access_role_arn = aws_iam_role.stack_access_role.arn
-    instance_role_arn = local.use_app_runner ? aws_iam_role.app_runner_instance_role[0].arn : ""
+    access_role_arn     = aws_iam_role.stack_access_role.arn
+    instance_role_arn   = local.use_app_runner ? aws_iam_role.app_runner_instance_role[0].arn : ""
     service_name_prefix = "zenml-${random_id.resource_name_suffix.hex}"
-    secret_name_prefix = "zenml-${random_id.resource_name_suffix.hex}"
+    secret_name_prefix  = "zenml-${random_id.resource_name_suffix.hex}"
   }
 }
 
 resource "zenml_stack_component" "deployer" {
-  count = local.use_app_runner ? 1 : 0
+  count  = local.use_app_runner ? 1 : 0
   name   = var.zenml_stack_name == "" ? "terraform-app-runner-${random_id.resource_name_suffix.hex}" : "${var.zenml_stack_name}-app-runner"
   type   = "deployer"
   flavor = "aws"
@@ -883,7 +883,7 @@ data "zenml_stack_component" "image_builder" {
 
 data "zenml_stack_component" "deployer" {
   count = local.use_app_runner ? 1 : 0
-  id = zenml_stack_component.deployer[0].id
+  id    = zenml_stack_component.deployer[0].id
 }
 
 data "zenml_stack" "stack" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,59 +1,59 @@
 output "s3_service_connector" {
   description = "The S3 service connector that was registered with the ZenML server"
-  value = data.zenml_service_connector.s3
+  value       = data.zenml_service_connector.s3
 }
 
 output "ecr_service_connector" {
   description = "The ECR service connector that was registered with the ZenML server"
-  value = data.zenml_service_connector.ecr
+  value       = data.zenml_service_connector.ecr
 }
 
 output "aws_service_connector" {
   description = "The generic AWS service connector that was registered with the ZenML server"
-  value = data.zenml_service_connector.aws
+  value       = data.zenml_service_connector.aws
 }
 
 output "artifact_store" {
   description = "The artifact store that was registered with the ZenML server"
-  value = data.zenml_stack_component.artifact_store
+  value       = data.zenml_stack_component.artifact_store
 }
 
 output "container_registry" {
   description = "The container registry that was registered with the ZenML server"
-  value = data.zenml_stack_component.container_registry
+  value       = data.zenml_stack_component.container_registry
 }
 
 output "orchestrator" {
   description = "The orchestrator that was registered with the ZenML server"
-  value = data.zenml_stack_component.orchestrator
+  value       = data.zenml_stack_component.orchestrator
 }
 
 output "step_operator" {
   description = "The step operator that was registered with the ZenML server"
-  value = data.zenml_stack_component.step_operator
+  value       = data.zenml_stack_component.step_operator
 }
 
 output "image_builder" {
   description = "The image builder that was registered with the ZenML server"
-  value = data.zenml_stack_component.image_builder
+  value       = data.zenml_stack_component.image_builder
 }
 
 output "deployer" {
   description = "The deployer that was registered with the ZenML server"
-  value = local.use_app_runner ? data.zenml_stack_component.deployer[0] : null
+  value       = local.use_app_runner ? data.zenml_stack_component.deployer[0] : null
 }
 
 output "zenml_stack" {
   description = "The ZenML stack that was registered with the ZenML server"
-  value = data.zenml_stack.stack
+  value       = data.zenml_stack.stack
 }
 
 output "zenml_stack_id" {
   description = "The ID of the ZenML stack that was registered with the ZenML server"
-  value = zenml_stack.stack.id
+  value       = zenml_stack.stack.id
 }
 
 output "zenml_stack_name" {
   description = "The name of the ZenML stack that was registered with the ZenML server"
-  value = zenml_stack.stack.name
+  value       = zenml_stack.stack.name
 }

--- a/test/main.tf
+++ b/test/main.tf
@@ -1,70 +1,72 @@
 terraform {
-    required_providers {
-        aws = {
-            source  = "hashicorp/aws"
-        }
-        zenml = {
-            source = "zenml-io/zenml"
-        }
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
     }
+    zenml = {
+      source = "zenml-io/zenml"
+    }
+  }
 }
 
 provider "aws" {
-    region = "eu-central-1"
+  region = "eu-central-1"
 }
 
 provider "zenml" {
-    # server_url = <taken from the ZENML_SERVER_URL environment variable if not set here>
-    # api_key = <taken from the ZENML_API_KEY environment variable if not set here>
+  # server_url = <taken from the ZENML_SERVER_URL environment variable if not set here>
+  # api_key = <taken from the ZENML_API_KEY environment variable if not set here>
 }
 
 module "zenml_stack" {
-    source  = "../"
+  source = "../"
 
-    orchestrator = "sagemaker" # or "skypilot" or "local"
-    zenml_stack_name = "aws-stack"
+  orchestrator     = "sagemaker" # or "skypilot" or "local"
+  zenml_stack_name = "aws-stack"
+  s3_force_destroy = true
+  ecr_force_delete = true
 }
 
 output "zenml_stack_id" {
-    value = module.zenml_stack.zenml_stack_id
-    sensitive = true
+  value     = module.zenml_stack.zenml_stack_id
+  sensitive = true
 }
 output "zenml_stack_name" {
-    value = module.zenml_stack.zenml_stack_name
-    sensitive = true
+  value     = module.zenml_stack.zenml_stack_name
+  sensitive = true
 }
 output "s3_service_connector" {
-    value = module.zenml_stack.s3_service_connector
-    sensitive = true
+  value     = module.zenml_stack.s3_service_connector
+  sensitive = true
 }
 output "ecr_service_connector" {
-    value = module.zenml_stack.ecr_service_connector
-    sensitive = true
+  value     = module.zenml_stack.ecr_service_connector
+  sensitive = true
 }
 output "aws_service_connector" {
-    value = module.zenml_stack.aws_service_connector
-    sensitive = true
+  value     = module.zenml_stack.aws_service_connector
+  sensitive = true
 }
 output "artifact_store" {
-    value = module.zenml_stack.artifact_store
-    sensitive = true
+  value     = module.zenml_stack.artifact_store
+  sensitive = true
 }
 output "container_registry" {
-    value = module.zenml_stack.container_registry
-    sensitive = true
+  value     = module.zenml_stack.container_registry
+  sensitive = true
 }
 output "orchestrator" {
-    value = module.zenml_stack.orchestrator
-    sensitive = true
+  value     = module.zenml_stack.orchestrator
+  sensitive = true
 }
 output "step_operator" {
-    value = module.zenml_stack.step_operator
-    sensitive = true
+  value     = module.zenml_stack.step_operator
+  sensitive = true
 }
 output "image_builder" {
-    value = module.zenml_stack.image_builder
-    sensitive = true
+  value     = module.zenml_stack.image_builder
+  sensitive = true
 }
 output "zenml_stack" {
-    value = module.zenml_stack.zenml_stack
+  value = module.zenml_stack.zenml_stack
 }

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,18 @@ variable "zenml_stack_name" {
   default     = ""
 }
 
+variable "s3_force_destroy" {
+  description = "Whether to force destroy the S3 artifact bucket when deleting the stack. If set to false, destroying the stack will fail if the bucket is not empty."
+  type        = bool
+  default     = false
+}
+
+variable "ecr_force_delete" {
+  description = "Whether to force delete the ECR container registry when deleting the stack. If set to false, destroying the stack will fail if the repository contains images."
+  type        = bool
+  default     = false
+}
+
 variable "zenml_stack_deployment" {
   description = "The deployment type for the ZenML stack. Used as a label for the registered ZenML stack."
   type        = string


### PR DESCRIPTION
This PR adds options in ZenML Tf AWS Module to allow users to force delete non-empty S3 bucket and ECR repo during stack deletion using terraform.

```tf
module "zenml_stack" {
  source           = "zenml-io/zenml-stack/aws"

  orchestrator     = "sagemaker" # or "skypilot" or "local"
  zenml_stack_name = "my-zenml-stack"
  s3_force_destroy = false
  ecr_force_delete = false
}

# ^^^Set `s3_force_destroy` and `ecr_force_delete` to true to allow deleting non-empty S3 bucket and ECR repository during terraform destroy
# If set to false (default), destroying the stack will fail if the S3 bucket or ECR repository is not empty
```