### PR TITLE
Add agent rules / documentation files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+This repository is a single Terraform module published as `zenml-io/zenml-stack/aws`. Keep module logic in the root Terraform files: `main.tf` defines AWS and ZenML resources, `variables.tf` defines inputs, and `outputs.tf` exposes registered connectors and stack components. `test/main.tf` is the example consumer used for integration-style checks with `source = "../"`. When you add or change inputs or outputs, update `README.md` and the test fixture in the same change.
+
+## Build, Test, and Development Commands
+- `terraform fmt` formats all `.tf` files; run it before every commit.
+- `terraform init` installs the AWS and ZenML providers in the current directory.
+- `terraform validate` checks syntax and provider wiring after init.
+- `terraform plan` previews changes for the root module; requires AWS credentials plus `ZENML_SERVER_URL` and `ZENML_API_KEY`.
+- `cd test && terraform init && terraform plan` verifies the module from a consumer configuration.
+
+Example setup:
+```bash
+export ZENML_SERVER_URL="https://your-zenml-server.com"
+export ZENML_API_KEY="your-api-key"
+aws configure
+```
+
+## Coding Style & Naming Conventions
+Use standard HCL formatting with two-space indentation; `terraform fmt` is the source of truth. Prefer descriptive `snake_case` names for variables, locals, and outputs such as `zenml_stack_name` and `use_implicit_auth`. Follow the existing pattern of concise comments only where conditional auth or version-gated behavior would otherwise be hard to follow.
+
+## Testing Guidelines
+There is no separate unit-test suite here; validation is Terraform-based. At minimum, run `terraform fmt`, `terraform validate`, and the `test/` plan before opening a PR. If you touch conditional logic for `orchestrator`, implicit auth, or ZenML version checks, mention which path you exercised in your PR.
+
+## Commit & Pull Request Guidelines
+Recent history mixes Conventional Commit prefixes (`feat:`, `docs:`) with short imperative summaries (`Fix secrets manager permissions`). Prefer concise, imperative subjects and use a prefix when it adds clarity. PRs should explain the AWS or ZenML behavior changed, list any new variables or outputs, and include README/test updates when interface changes are user-facing.
+
+## Security & Configuration Tips
+Do not commit AWS credentials, ZenML API keys, or Terraform state. Use environment variables for ZenML provider auth, and keep account-specific values out of defaults and examples unless they are intentionally public constants.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,3 +66,14 @@ After creating AWS resources, the module registers them with ZenML in this order
 3. A **zenml_stack** resource that ties all components together
 
 Each ZenML resource is re-read via a `data` source after creation so the outputs reflect server-side state.
+
+## Releasing
+
+The Terraform Registry is driven by **Git tags**, not by branch state. Merging a PR to `main` does NOT update the Registry. After merging changes that should be published:
+
+```bash
+git tag v<next-version>   # e.g. v2.0.11
+git push origin v<next-version>
+```
+
+The Registry webhook picks up new semver tags automatically (usually within a few minutes). Always tag after merging — don't forget this step.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+A Terraform module that provisions AWS infrastructure for a ZenML ML stack and automatically registers it with a ZenML server. It is published to the Terraform Registry as `zenml-io/zenml-stack/aws`.
+
+## Commands
+
+```bash
+# Format all .tf files (required before committing)
+terraform fmt
+
+# Validate configuration syntax
+terraform validate
+
+# Preview changes (requires AWS credentials + ZenML server)
+terraform plan
+
+# Apply changes
+terraform apply
+
+# Test using the example configuration
+cd test && terraform init && terraform plan
+```
+
+Formatting and validation don't need cloud credentials. Anything beyond that (plan/apply) requires both AWS CLI configured (`aws configure`) and ZenML server env vars:
+```bash
+export ZENML_SERVER_URL="https://your-zenml-server.com"
+export ZENML_API_KEY="your-api-key"
+```
+
+## Architecture
+
+**Single-module, three-file structure:**
+
+| File | Purpose |
+|------|---------|
+| `main.tf` | All resources, data sources, locals, and ZenML stack registration |
+| `variables.tf` | Five input variables (orchestrator, stack name, s3_force_destroy, ecr_force_delete, zenml_stack_deployment) |
+| `outputs.tf` | Exposes all created service connectors, stack components, and the stack itself |
+| `test/main.tf` | Example consumer of the module (`source = "../"`) for integration testing |
+
+**Providers:** `hashicorp/aws` (~> 4.0) and `zenml-io/zenml`.
+
+### Key Conditional Logic in main.tf
+
+The module's behavior branches on three axes — understanding these is essential for making changes:
+
+1. **Auth method** (`local.use_implicit_auth`): ZenML Pro uses cross-account IAM role assumption (no secrets shared). Self-hosted ZenML or SkyPilot on Pro falls back to creating an IAM user with access keys. Controls whether `aws_iam_user` and `aws_iam_access_key` resources are created (count = 0/1).
+
+2. **Orchestrator** (`var.orchestrator`): `"sagemaker"` | `"skypilot"` | `"local"`. Each path creates different IAM policies and stack component configurations. SageMaker adds EventBridge scheduler permissions; SkyPilot adds EC2/instance profile permissions; local creates no orchestrator-specific IAM.
+
+3. **ZenML version** (`local.use_codebuild`, `local.use_app_runner`): CodeBuild image builder requires ZenML >0.70.0; App Runner deployer requires >0.85.0. Older versions get a local image builder and no deployer.
+
+### Resource Naming
+
+All AWS resources use the pattern `zenml-${random_id.resource_name_suffix.hex}` to avoid collisions. The random suffix is a 6-byte random ID (12 hex chars).
+
+### ZenML Stack Registration Flow
+
+After creating AWS resources, the module registers them with ZenML in this order:
+1. Three **service connectors** (S3, ECR, generic AWS) — each with auth config matching the implicit/IAM-role decision
+2. **Stack components** (artifact_store, container_registry, orchestrator, step_operator, image_builder, optionally deployer)
+3. A **zenml_stack** resource that ties all components together
+
+Each ZenML resource is re-read via a `data` source after creation so the outputs reflect server-side state.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+## Development
+
+Format your code before committing:
+
+```bash
+terraform fmt
+```
+
+Validate syntax:
+
+```bash
+terraform validate
+```
+
+Test against the example configuration in `test/`:
+
+```bash
+cd test && terraform init && terraform plan
+```
+
+## Releasing to the Terraform Registry
+
+This module is published to the [Terraform Registry](https://registry.terraform.io/modules/zenml-io/zenml-stack/aws). The Registry updates are triggered by **Git tags**, not by merging to `main`.
+
+After merging a PR that should be published as a new version:
+
+```bash
+git tag v<next-version>
+git push origin v<next-version>
+```
+
+Use semantic versioning. The Registry typically picks up new tags within a few minutes.


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` with module architecture overview and development commands for AI-assisted development
- Adds `CONTRIBUTING.md` with development workflow and **release instructions**

## Important: Terraform Registry release process

PR #5 was merged but the Terraform Registry still shows the old version. This is because **the Registry is driven by Git tags, not by branch merges**. After merging a PR that should be published:

```bash
git tag v<next-version>   # e.g. v2.0.11
git push origin v<next-version>
```

The Registry picks up new semver tags automatically within a few minutes. This release step was missed after PR #5 — both new docs now include this as a documented process so it doesn't get forgotten again.

## Action needed

After merging this PR, please also tag and push to publish both PR #5's changes and this one to the Registry:

```bash
git pull origin main
git tag v2.0.11
git push origin v2.0.11
```

## Test plan

- [x] Verify CLAUDE.md content accurately describes the module
- [x] Verify CONTRIBUTING.md release instructions are clear
- [ ] After merge: tag and push to update Terraform Registry